### PR TITLE
Prepare 2.x

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0, 8.1]
+        php: [7.3, 7.4, 8.0, 8.1]
 
     name: PHP ${{ matrix.php }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: lint
+name: Lint
 
 on:
   pull_request:
@@ -7,9 +7,9 @@ on:
       - master
 
 jobs:
-  ecs:
+  lint:
     runs-on: ubuntu-latest
-    name: PHP ${{ matrix.php }}
+    name: Lint
 
     steps:
       - name: Checkout code

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,11 +9,6 @@ on:
 jobs:
   ecs:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        php: [7.3, 7.4, 8.0, 8.1]
-
     name: PHP ${{ matrix.php }}
 
     steps:
@@ -22,9 +17,6 @@ jobs:
 
       - name: Setup PHP
         uses: shivammathur/setup-php@2.17.0
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
 
       - name: Install dependencies
         uses: ramsey/composer-install@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0, 8.1]
+        php: [7.3, 7.4, 8.0, 8.1]
         stability: [lowest, highest]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: tests
+name: Tests
 
 on:
   pull_request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,5 +52,5 @@ composer lint:phpstan
 
 Unit tests:
 ```bash
-composer test:unit
+composer test:phpunit
 ```

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,11 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev"
+        }
+    },
     "require": {
         "php": "^7.2 || ^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
         }
     },
     "require": {
-        "php": "^7.2 || ^8.0"
+        "php": "^7.3 || ^8.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.0",
-        "phpunit/phpunit": "^8.0,<8.5.12 || ^9.3.3",
-        "zing/coding-standard": "^5.3 || ^6.0"
+        "phpunit/phpunit": "^9.3.3",
+        "zing/coding-standard": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/ecs.php
+++ b/ecs.php
@@ -7,7 +7,7 @@ use Symplify\EasyCodingStandard\ValueObject\Option;
 use Zing\CodingStandard\Set\ECSSetList;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(ECSSetList::PHP_72);
+    $containerConfigurator->import(ECSSetList::PHP_73);
     $containerConfigurator->import(ECSSetList::CUSTOM);
 
     $parameters = $containerConfigurator->parameters();

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,13 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-        beStrictAboutOutputDuringTests="true"
-        bootstrap="vendor/autoload.php"
-        colors="true"
-        convertDeprecationsToExceptions="true"
-        failOnRisky="true"
-        failOnWarning="true"
-        verbose="true"
->
-    <testsuites>
-        <testsuite name="Package Skeleton PHP Test Suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" beStrictAboutOutputDuringTests="true" bootstrap="vendor/autoload.php" colors="true" convertDeprecationsToExceptions="true" failOnRisky="true" failOnWarning="true" verbose="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Package Skeleton PHP Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ use Zing\CodingStandard\Set\RectorSetList;
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(RectorSetList::CUSTOM);
     $containerConfigurator->import(PHPUnitSetList::PHPUNIT_CODE_QUALITY);
-    $containerConfigurator->import(LevelSetList::UP_TO_PHP_72);
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_73);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set(


### PR DESCRIPTION
- [x] [Composer] Bump minimum version of PHP to 7.3
- [x] [Composer] Bump minimum version of PHPUnit to 9.3.3
- [x] [ECS] Bump minimum version of PHP to 7.3
- [x] [Rector] Bump minimum version of PHP to 7.3
- [x] [PHPUnit] Migrate PHPUnit configuration
- [x] [Composer] Update branch-alias
- [ ] [GA] Drop PHP 7.2 from matrix

Fixes https://github.com/zingimmick/package-skeleton-php/issues/92, https://github.com/zingimmick/package-skeleton-php/issues/91, https://github.com/zingimmick/package-skeleton-php/issues/90, https://github.com/zingimmick/package-skeleton-php/issues/89,https://github.com/zingimmick/package-skeleton-php/issues/88
